### PR TITLE
remove reliance on old trait solver bug

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -12,7 +12,7 @@ where
     Q: Query + 'static,
 {
     Box::new(QueryHandler {
-        query: PhantomData,
+        query: PhantomData::<Q>,
         system,
     })
 }


### PR DESCRIPTION
Hi there :wave: we discovered this project during [a crater run](https://github.com/rust-lang/crater) with the [next-generation trait solver](https://blog.rust-lang.org/inside-rust/2023/07/17/trait-system-refactor-initiative/) in https://github.com/rust-lang/rust/pull/133502.

The generic parameter `Q` of `QueryHandler` is underconstrained here as it could be any type `T` with `<T as Query>::Refs<'a>` being equal to `<Q as Query>::Refs<'a>`. It isn't actually necessary for `T` to be `Q` itself, e.g. it could also be a type which delegates to `Q`s `Query` impl. The current type system implementation unnecessarily constrained `T` to be equal to `Q`. This will no longer be the case with the new trait solver.

See https://github.com/rust-lang/trait-system-refactor-initiative/issues/168 or [the related breakage in `bevy`](https://github.com/bevyengine/bevy/pull/18840) for more details .

I am sorry for the inconvenience and am available in case there are any questions. 